### PR TITLE
updated @types/react-test-renderer to v16

### DIFF
--- a/react-native-scripts/src/scripts/init.js
+++ b/react-native-scripts/src/scripts/init.js
@@ -20,7 +20,7 @@ const DEFAULT_DEV_DEPENDENCIES = {
   '@types/jest': '^20.0.8',
   '@types/react': '^16.0.5',
   '@types/react-native': '^0.48.4',
-  '@types/react-test-renderer': '^15.5.4',
+  '@types/react-test-renderer': '^16.0.0',
   'jest-expo-ts': '^21.0.0',
   'react-native-typescript-transformer': '^1.1.4',
   'react-test-renderer': '16.0.0-alpha.12',


### PR DESCRIPTION
This fixes an issue that can occur if your type definitions depend on different version of the React typings. See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/21242