### PR TITLE
Configure jest for TypeScript.

### DIFF
--- a/react-native-scripts/src/scripts/init.js
+++ b/react-native-scripts/src/scripts/init.js
@@ -81,6 +81,30 @@ https://github.com/npm/npm/issues/16991
     test: 'node node_modules/jest/bin/jest.js',
   };
 
+  appPackage.jest = {
+    globals: {
+      'ts-jest': {
+        useBabelrc: true,
+      },
+    },
+    moduleFileExtensions: [
+      'ts',
+      'tsx',
+      'js',
+      'jsx',
+      'json',
+      'node',
+    ],
+    preset: 'jest-expo',
+    testMatch: [
+      '**/__tests__/**/*.[tj]s?(x)',
+      '**/?(*.)(spec|test).[tj]s?(x)',
+    ],
+    transform: {
+      '^.+\\.tsx?$': 'ts-jest',
+    },
+  };
+
   if (!appPackage.dependencies) {
     appPackage.dependencies = {};
   }


### PR DESCRIPTION
When initializing package.json for the created app, the jest key needs
to be configured properly to enable jest to discover and properly load
the test files.

Fixes #7 where running npm test would fail to discover or run the
tests and then report no tests found.