### PR TITLE
Update package.json to include the repository

### DIFF
--- a/create-react-native-app/package.json
+++ b/create-react-native-app/package.json
@@ -7,6 +7,11 @@
     "react-native",
     "react"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mathieudutour/create-react-native-app-typescript.git",
+    "directory": "packages/create-react-native-app"
+  },
   "homepage": "https://github.com/react-community/create-react-native-app",
   "bugs": "https://github.com/react-community/create-react-native-app",
   "preferGlobal": true,

--- a/create-react-native-app/package.json
+++ b/create-react-native-app/package.json
@@ -10,7 +10,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/mathieudutour/create-react-native-app-typescript.git",
-    "directory": "packages/create-react-native-app"
+    "directory": "create-react-native-app"
   },
   "homepage": "https://github.com/react-community/create-react-native-app",
   "bugs": "https://github.com/react-community/create-react-native-app",

--- a/react-native-scripts/package.json
+++ b/react-native-scripts/package.json
@@ -10,7 +10,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/mathieudutour/create-react-native-app-typescript.git",
-    "directory": "packages/react-native-scripts"
+    "directory": "react-native-scripts"
   },
   "homepage": "https://github.com/mathieudutour/create-react-native-app-typescript",
   "bugs": "https://github.com/mathieudutour/create-react-native-app-typescript",

--- a/react-native-scripts/package.json
+++ b/react-native-scripts/package.json
@@ -7,6 +7,11 @@
     "react-native",
     "react"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mathieudutour/create-react-native-app-typescript.git",
+    "directory": "packages/react-native-scripts"
+  },
   "homepage": "https://github.com/mathieudutour/create-react-native-app-typescript",
   "bugs": "https://github.com/mathieudutour/create-react-native-app-typescript",
   "engines": {


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR.

Published NPM packages with repository information:
• create-react-native-app
• react-native-scripts-ts